### PR TITLE
Ajout de MCP dans les sources autorisées de fontes

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
       "directives": {
         "defaultSrc": ["'self'"],
         "imgSrc": ["data:"],
-        "fontSrc": ["data:"]
+        "fontSrc": ["data:", "moncomptepro.beta.gouv.fr"]
       }
     },
     "db": {
@@ -23,7 +23,7 @@
       "directives": {
         "defaultSrc": ["'self'"],
         "imgSrc": ["data:"],
-        "fontSrc": ["data:"]
+        "fontSrc": ["data:", "moncomptepro.beta.gouv.fr"]
       }
     }
   }


### PR DESCRIPTION

Suite à une demande de @rdubigny j'ajoute MCP dans la CSP pour pouvoir inclure des polices depuis là-bas.
Tu me diras quand même pourquoi ? :)

Déployé en staging : 

![Capture d’écran 2023-10-25 à 10 28 37](https://github.com/betagouv/pad.numerique.gouv.fr/assets/1035145/1842f5a1-d35a-4d75-8f81-61f5e3e8a118)
