### PR TITLE
header: add the gaufre suite numérique button

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -7,8 +7,8 @@ const CspStrategy = {}
 const defaultDirectives = {
   defaultSrc: ['\'none\''],
   baseUri: ['\'self\''],
-  connectSrc: ['\'self\'', buildDomainOriginWithProtocol(config, 'ws')],
-  fontSrc: ['\'self\''],
+  connectSrc: ['\'self\'', buildDomainOriginWithProtocol(config, 'ws'), 'https://integration.lasuite.numerique.gouv.fr/'],
+  fontSrc: ['\'self\'', 'https://integration.lasuite.numerique.gouv.fr/'],
   manifestSrc: ['\'self\''],
   frameSrc: ['\'self\'', 'https://player.vimeo.com', 'https://www.slideshare.net/slideshow/embed_code/key/', 'https://www.youtube.com'],
   imgSrc: ['*'], // we allow using arbitrary images
@@ -19,6 +19,7 @@ const defaultDirectives = {
     'https://gist.github.com/',
     'https://vimeo.com/api/oembed.json',
     'https://www.slideshare.net/api/oembed/2',
+    'https://integration.lasuite.numerique.gouv.fr/',
     '\'unsafe-inline\'' // this is ignored by browsers supporting nonces/hashes
   ],
   styleSrc: [config.serverURL + '/build/', config.serverURL + '/css/', '\'unsafe-inline\'', 'https://github.githubassets.com'], // unsafe-inline is required for some libs, plus used in views

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "@gouvfr-lasuite/integration": "1.0.1",
     "@gouvfr/dsfr": "=1.1.0",
     "@passport-next/passport-openid": "1.0.0",
     "Idle.Js": "git+https://github.com/shawnmclean/Idle.js",

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -18,6 +18,11 @@
   color: var(--g700);
 }
 
+.fr-header__navbar {
+  margin-top: .25rem;
+  margin-right: .25rem;
+}
+
 a:focus, a:hover {
   color: inherit;
   text-decoration: none;

--- a/public/views/includes/scripts.ejs
+++ b/public/views/includes/scripts.ejs
@@ -2,3 +2,4 @@
 <% for (var js in htmlWebpackPlugin.files.js) { %>
 <script src="<%= htmlWebpackPlugin.files.js[js] %>" defer></script>
 <% } %>
+<script id="lasuite-gaufre-script" async defer src="https://integration.lasuite.numerique.gouv.fr/api/v1/gaufre.js"></script>

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -11,6 +11,15 @@
                         <br>Française
                     </p>
                     </div>
+                    <div class="fr-header__navbar">
+                        <button
+                            type="button"
+                            class="lasuite-gaufre-btn lasuite-gaufre-btn--vanilla js-lasuite-gaufre-btn"
+                            title="Les services de La Suite numérique"
+                        >
+                            Les services de La Suite numérique
+                        </button>
+                    </div>
                 </div>
                 <div class="fr-header__service">
                     <a href="/" title="Accueil - Pad numerique">
@@ -18,6 +27,21 @@
                     </a>
                     <p class="fr-header__service-tagline">Plateforme de notes collaboratives</p>
                 </div>
+                </div>
+                <div class="fr-header__tools">
+                    <div class="fr-header__tools-links">
+                        <ul class="fr-btns-group">
+                            <li>
+                                <button
+                                    type="button"
+                                    class="lasuite-gaufre-btn lasuite-gaufre-btn--vanilla js-lasuite-gaufre-btn"
+                                    title="Les services de La Suite numérique"
+                                >
+                                    Les services de La Suite numérique
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
             </div>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -164,7 +164,8 @@ module.exports = {
       path.join(__dirname, 'public/css/bootstrap-social.css'),
       path.join(__dirname, 'node_modules/select2/select2.css'),
       path.join(__dirname, 'node_modules/select2/select2-bootstrap.css'),
-      path.join(__dirname, 'node_modules/@gouvfr/dsfr/dist/css/dsfr.min.css')
+      path.join(__dirname, 'node_modules/@gouvfr/dsfr/dist/css/dsfr.min.css'),
+      path.join(__dirname, 'node_modules/@gouvfr-lasuite/integration/dist/css/gaufre.css')
     ],
     'cover-pack': [
       'babel-polyfill',

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,6 +275,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gouvfr-lasuite/integration@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@gouvfr-lasuite/integration@npm:1.0.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: "*"
+    react-dom: "*"
+    typescript: "*"
+  checksum: fb199453572f5982cb5f524a5c3209a55d3b0a972e17df68babaa66d180fc9ed4495f6b8847c0780e0af50b356498904ad188343ddd389ddcc3097c6ca595cee
+  languageName: node
+  linkType: hard
+
 "@gouvfr/dsfr@npm:=1.1.0":
   version: 1.1.0
   resolution: "@gouvfr/dsfr@npm:1.1.0"
@@ -1196,6 +1209,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "HedgeDoc@workspace:."
   dependencies:
+    "@gouvfr-lasuite/integration": 1.0.1
     "@gouvfr/dsfr": =1.1.0
     "@hedgedoc/codemirror-5": 5.65.12
     "@passport-next/passport-openid": 1.0.0


### PR DESCRIPTION
Add the "Gaufre" button that allows users to easily switch between all La Suite services:


https://github.com/betagouv/pad.numerique.gouv.fr/assets/221253/e901b714-9147-4767-8dfe-b0ec1554792f

pouet @BenoitSerrano @lebaudantoine 
