### PR TITLE
🚸(frontend) display "beta" tag near app title

### DIFF
--- a/public/css/cover.css
+++ b/public/css/cover.css
@@ -267,3 +267,16 @@ select {
 .cover-heading img {
     max-width: 100%;
 }
+
+.beta-tag {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: -0.02rem;
+  padding: 0 0.25rem;
+  background: var(--lasuite-primary);
+  color: white;
+  font-size: 0.625rem;
+  border-radius: 0 0.1875rem 0 0.1875rem;
+  margin: 0 0 0.9375rem 0.3125rem;
+  line-height: 1rem;
+}

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -10,9 +10,10 @@
                             </div>
                         </div>
                         <div class="fr-header__service lasuite-header__service">
-                            <a class="lasuite-header__service-link ui-home" href="/" title="Accueil - Notepad de l'État" aria-label="Accueil - Notepad de l'État">
+                            <a class="lasuite-header__service-link ui-home" href="/" title="Accueil - Notepad de l'État" aria-label="Accueil - Notepad de l'État (beta)">
                                 <img src="/build/lasuite/logo.svg" alt="" class="lasuite-header__service-logo fr-responsive-img" width="32" height="32">
                                 <p class="fr-header__service-title lasuite-header__service-title">Notepad de l'État</p>
+                                <p class="beta-tag">beta</p>
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
As the app is currently not secure and not fully homologated, we have decided to display a "beta" tag next to the app title. This will visually notify users that the app is still under construction.

A new version of the pad will be delivered as soon as possible.

https://github.com/betagouv/pad.numerique.gouv.fr/assets/45729124/65e5d6db-b0b4-4e3c-bc1a-ee521082d69d


