### PR TITLE
🐛 (backend) force AgentConnect `profileId` to Lowercase

### DIFF
--- a/lib/web/auth/agentConnect/index.js
+++ b/lib/web/auth/agentConnect/index.js
@@ -119,7 +119,7 @@ passport.use(new AgentConnectStrategy({}, function (profileId, profile, done) {
   const stringifiedProfile = JSON.stringify(profile)
   models.User.findOrCreate({
     where: {
-      profileid: profileId
+      profileid: profileId.toLowerCase()
     },
     defaults: {
       profile: stringifiedProfile


### PR DESCRIPTION
The `profileId` provided by identity providers is not always in lowercase. During the migration from MCP to Agent Connect, a few users lost their documents because their identity provider returned a capitalized email. This issue primarily affected users of development durable connected with Cerbere.

Although it should be the responsibility of the identity provider to manage email addresses, reconciling based on email case sensitivity is poor practice. This commit enforces handling `profileId` as case-insensitive to mitigate this issue, even if it diverges from the specification.

Note: This change might introduce future regressions. However, @sampaccoud and @rdubigny have approved this approach.