### PR TITLE
docker: fix the Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 node_modules
 Dockerfile
 docker-compose.yml
+public/build
+public/views/build

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,5 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.7.0.cjs
+
+checksumBehavior: update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,15 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
-
 COPY ./bin/heroku ./bin/heroku
 
-RUN yarn
+RUN corepack enable yarn
+
+COPY package.json yarn.lock .yarnrc.yml ./
+
+COPY .yarn .yarn/
+
+RUN yarn install
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     image: betagouv-hedgedoc


### PR DESCRIPTION
Now that we/they use Yarn Berry it is necessary to mount the Yarn configuration (.yarnrc.yml) and its folder (.yarn) into the Docker container otherwise we cannot specify that we want the legacy way of installing packages into the node_modules folder, which is discontinued by default[1].

[1]: https://yarnpkg.com/features/pnp
