### PR TITLE
home: fix the headline

### DIFF
--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -103,10 +103,10 @@
                             <div class="lasuite-homepage__main-col">
                                 <div class="lasuite-homepage__tagline-container">
                                     <h1 class="lasuite-homepage__tagline">
-                                        <strong class="lasuite-homepage__tagline-strong">Notepad de l’État</strong>
-                                        <br role="presentation">Le meilleur moyen d’écrire
-                                        <br role="presentation"> et partager votre savoir
-                                        <br role="presentation"> en markdown
+                                      <strong class="lasuite-homepage__tagline-strong">Notepad de l’État</strong>
+                                      <br role="presentation">Le meilleur moyen d’écrire
+                                      <br role="presentation"> et de partager vos notes
+                                      <br role="presentation"> au <a target="_blank" href="https://pad.numerique.gouv.fr/O-jXOiSrSSahTdTFiaDXJA?both#">format Markdown</a>.
                                     </h1>
                                 </div>
                             </div>


### PR DESCRIPTION
Markdown is capitalised and since most people do *not* know what it
make it explicit by saying "format" linked to an introduction.

P.S: I would personally delete the whole bit about Markdown, not sure
it's relevant in that particular section.