### PR TITLE
Add a tutorial on newly introduce Spell Checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "graceful-fs": "4.2.11",
     "helmet": "4.6.0",
     "i18n": "0.15.1",
+    "intro.js": "7.2.0",
     "is-svg": "4.4.0",
     "jsdom-nogyp": "0.8.3",
     "lodash": "4.17.21",

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -521,6 +521,7 @@ div[contenteditable]:empty:not(:focus):before{
 
 .status-bar .status-indicators .status-keymap > a,
 .status-bar .status-indicators .status-theme > a,
+.status-bar .status-indicators .status-feedbacks > a,
 .status-bar .status-indicators .status-spellcheck > a,
 .status-bar .status-indicators .status-preferences > a {
     color: inherit;
@@ -528,6 +529,7 @@ div[contenteditable]:empty:not(:focus):before{
 }
 
 .status-bar .status-indicators .status-theme,
+.status-bar .status-indicators .status-feedbacks,
 .status-bar .status-indicators .status-spellcheck,
 .status-bar .status-indicators .status-preferences {
     padding: 0 4.3px;
@@ -609,7 +611,8 @@ div[contenteditable]:empty:not(:focus):before{
     display: none;
 }
 
-.status-bar .status-overwrite:hover, .status-bar .indent-type:hover, .status-bar .indent-width-label:hover {
+.status-bar .status-overwrite:hover, .status-bar .indent-type:hover, .status-bar .feedbacks-text:hover, .status-bar .indent-width-label:hover {
+    text-underline-offset: 4px;
     text-decoration: underline;
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -11,6 +11,10 @@ body {
     /*overflow: hidden;*/
 }
 
+body.introjs-tour {
+  overflow: hidden;
+}
+
 .night a,
 .night .open-files-container li.selected a {
     color: #5EB7E0;

--- a/public/css/spell-checker.css
+++ b/public/css/spell-checker.css
@@ -154,3 +154,10 @@
   box-shadow: white 0 0 1px 2px, rgba(33, 33, 33, 0.7) 0 0 0 5000px !important;
 }
 
+/**
+* IntroJs defaults to showing a checkbox that we don't want.
+* Tour should always be shown once; No user choice.
+*/
+.introjs-dontShowAgain {
+  display: none !important;
+}

--- a/public/css/spell-checker.css
+++ b/public/css/spell-checker.css
@@ -138,7 +138,7 @@
 }
 
 .spell-check-status.error {
-  background-color: rgba(255,0,0,.8);
+  background-color: rgba(255,0,0,1);
 }
 
 #status-infinity-icon, #status-errors-count, #status-network-error-icon {

--- a/public/css/spell-checker.css
+++ b/public/css/spell-checker.css
@@ -112,7 +112,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
 }
 
 .spell-check-status:hover, .spell-check-status:visited {

--- a/public/css/spell-checker.css
+++ b/public/css/spell-checker.css
@@ -150,3 +150,7 @@
   display: block;
 }
 
+.custom-introjs-helperLayer {
+  box-shadow: white 0 0 1px 2px, rgba(33, 33, 33, 0.7) 0 0 0 5000px !important;
+}
+

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -87,6 +87,7 @@ import modeType from './lib/modeType'
 import appState from './lib/appState'
 import { SpellChecker, DELETE_DOUBLE_SPACE_VALUE } from './lib/spell-checker/spell-checker'
 import config from './lib/editor/config'
+import { closeTutorial, initTutorial } from './lib/spell-checker/tutorial'
 
 require('../vendor/showup/showup')
 
@@ -1155,6 +1156,12 @@ function changeMode (type) {
     modeIcon.addClass('fa-pencil')
   }
   unlockNavbar()
+
+  if (appState.currentMode !== modeType.view) {
+    initTutorial()
+  } else {
+    closeTutorial()
+  }
 }
 
 function lockNavbar () {

--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -570,7 +570,7 @@ export default class Editor {
     this.statusSpellcheck = this.statusBar.find('.status-spellcheck')
     const spellcheckToggle = this.statusSpellcheck.find('.ui-spellcheck-toggle')
 
-    const cookieSpellcheck = Cookies.get('spellcheck')
+    const cookieSpellcheck = Cookies.get('spellcheck-v2')
     if (cookieSpellcheck) {
       let mode = null
       if (cookieSpellcheck === 'true' || cookieSpellcheck === true) {
@@ -588,6 +588,10 @@ export default class Editor {
           spellcheckToggle.addClass('active')
         }
       }
+    } else if (cookieSpellcheck === undefined) {
+      this.editor.setOption('mode', config.spellCheckerMode)
+      SpellChecker.fetchData(this.editor)
+      spellcheckToggle.addClass('active')
     }
 
     spellcheckToggle.click(() => {
@@ -607,7 +611,7 @@ export default class Editor {
           spellcheckToggle.addClass('active')
         }
       }
-      Cookies.set('spellcheck', mode === config.spellCheckerMode, {
+      Cookies.set('spellcheck-v2', mode === config.spellCheckerMode, {
         expires: 365,
         sameSite: window.cookiePolicy,
         secure: window.location.protocol === 'https:'

--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -125,7 +125,7 @@ export default class Editor {
       Tab: function (cm) {
         const tab = '\t'
 
-        // contruct x length spaces
+        // construct x length spaces
         const spaces = Array(parseInt(cm.getOption('indentUnit')) + 1).join(' ')
 
         // auto indent whole line when in list or blockquote
@@ -614,7 +614,7 @@ export default class Editor {
       })
     })
 
-    // workaround spellcheck might not activate beacuse the ajax loading
+    // workaround spellcheck might not activate because the ajax loading
     if (window.num_loaded < 2) {
       const spellcheckTimer = setInterval(
         () => {

--- a/public/js/lib/editor/statusbar.html
+++ b/public/js/lib/editor/statusbar.html
@@ -31,6 +31,12 @@
             <div class="indent-width-label" title="Click to change indentation size">4</div>
             <input class="indent-width-input hidden" type="number" min="1" max="10" maxlength="2" size="2">
         </div>
+        <div class="status-feedbacks">
+            <a class="ui-feedbacks" title="Partagez vos retours" href="https://grist.incubateur.net/o/docs/forms/mxmyvAB6sBThkX5CarmwZt/4" target="_blank">
+                <span class="feedbacks-text">Feedbacks</span>
+                <i class="fa fa-external-link fa-fw"></i>
+            </a>
+        </div>
         <div class="status-theme">
             <a class="ui-theme-toggle" title="Toggle editor theme"><i class="fa fa-sun-o fa-fw"></i></a>
         </div>

--- a/public/js/lib/spell-checker/spell-checker.js
+++ b/public/js/lib/spell-checker/spell-checker.js
@@ -477,11 +477,8 @@ SpellChecker.initStatus = () => {
     return
   }
 
-  const status = document.createElement('a')
+  const status = document.createElement('div')
   status.className = 'spell-check-status'
-  status.title = 'Feedbacks'
-  status.target = '_blank'
-  status.href = 'https://grist.incubateur.net/o/docs/forms/mxmyvAB6sBThkX5CarmwZt/4'
 
   const codeMirrorEditor = document.querySelector('.CodeMirror')
 

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -6,6 +6,7 @@ export function initTutorial () {
     nextLabel: 'Suivant',
     prevLabel: 'Précédent',
     doneLabel: 'Terminé',
+    highlightClass: 'custom-introjs-helperLayer',
     steps: [
       {
         title: 'Nouveauté',

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -21,13 +21,18 @@ export function initTutorial () {
     steps: [
       {
         title: 'Nouveauté',
-        intro: "La correction orthographique est disponible en version bêta. Vous pouvez l'activer ou la désactiver en cochant cette case.",
+        intro: "Un correcteur d’orthographe et de grammaire est disponible en version bêta. Vous pouvez l'activer ou la désactiver en cochant cette case.",
         element: spellCheckToggle
       },
       {
-        title: 'Alertes et retours',
-        intro: "Cette icône vous alerte en temps réel sur l'orthographe de votre document. \n\nLors de la rédaction d'un document, cliquez dessus pour nous partager vos retours sur la fonctionnalité.",
+        title: 'Temps réel',
+        intro: "Il corrige et reformule vos phrases en temps réel. Ce statut vous informera de l'état de votre document.",
         element: spellCheckStatus
+      },
+      {
+        title: 'Retours',
+        intro: 'Une fois le tutoriel terminé, cliquez à tout moment sur ce lien pour partager vos retours.',
+        element: document.querySelector('.ui-feedbacks')
       }
     ]
   })

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -37,6 +37,9 @@ export function initTutorial () {
       }
     ]
   })
+  intro.onstart(() => {
+    document.querySelector('body').classList.add('introjs-tour')
+  })
   intro.onexit(() => {
     document.querySelector('body').classList.remove('introjs-tour')
     intro.setDontShowAgain(true)

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -15,6 +15,7 @@ export function initTutorial () {
     prevLabel: 'Précédent',
     doneLabel: 'Terminé',
     highlightClass: 'custom-introjs-helperLayer',
+    dontShowAgainCookie: 'spellcheck-tutorial-dontShowAgain',
     showBullets: false,
     disableInteraction: true,
     exitOnOverlayClick: false,

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -1,0 +1,26 @@
+import introJs from 'intro.js'
+import 'intro.js/introjs.css'
+
+export function initTutorial () {
+  introJs().setOptions({
+    nextLabel: 'Suivant',
+    prevLabel: 'Précédent',
+    doneLabel: 'Terminé',
+    steps: [
+      {
+        title: 'Nouveauté',
+        intro: "La correction orthographique est disponible en version bêta. Vous pouvez l'activer ou la désactiver en cochant cette case.",
+        element: document.querySelector('.status-spellcheck')
+      },
+      {
+        title: 'Alertes et retours',
+        intro: "Cette icône vous alerte en temps réel sur l'orthographe de votre document. \n\nLors de la rédaction d'un document, cliquez dessus pour nous partager vos retours sur la fonctionnalité.",
+        element: document.querySelector('.spell-check-status')
+      }
+    ]
+  }).start()
+}
+
+export function closeTutorial () {
+  introJs().exit()
+}

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -2,6 +2,13 @@ import introJs from 'intro.js'
 import 'intro.js/introjs.css'
 
 export function initTutorial () {
+  const spellCheckToggle = document.querySelector('.status-spellcheck')
+  const spellCheckStatus = document.querySelector('.spell-check-status')
+
+  if (!spellCheckToggle || !spellCheckStatus) {
+    return
+  }
+
   introJs().setOptions({
     nextLabel: 'Suivant',
     prevLabel: 'Précédent',
@@ -12,12 +19,12 @@ export function initTutorial () {
       {
         title: 'Nouveauté',
         intro: "La correction orthographique est disponible en version bêta. Vous pouvez l'activer ou la désactiver en cochant cette case.",
-        element: document.querySelector('.status-spellcheck')
+        element: spellCheckToggle
       },
       {
         title: 'Alertes et retours',
         intro: "Cette icône vous alerte en temps réel sur l'orthographe de votre document. \n\nLors de la rédaction d'un document, cliquez dessus pour nous partager vos retours sur la fonctionnalité.",
-        element: document.querySelector('.spell-check-status')
+        element: spellCheckStatus
       }
     ]
   }).start()

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -10,6 +10,7 @@ export function initTutorial () {
   }
 
   introJs().setOptions({
+    dontShowAgain: true, // Override styles to hide the checkbox
     nextLabel: 'Suivant',
     prevLabel: 'Précédent',
     doneLabel: 'Terminé',
@@ -28,6 +29,9 @@ export function initTutorial () {
       }
     ]
   }).start()
+  // Set a cookie to prevent showing the tutorial again
+  // This ensures the tutorial is shown only once
+  introJs().setDontShowAgain(true)
 }
 
 export function closeTutorial () {

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -7,6 +7,7 @@ export function initTutorial () {
     prevLabel: 'Précédent',
     doneLabel: 'Terminé',
     highlightClass: 'custom-introjs-helperLayer',
+    showBullets: false,
     steps: [
       {
         title: 'Nouveauté',

--- a/public/js/lib/spell-checker/tutorial.js
+++ b/public/js/lib/spell-checker/tutorial.js
@@ -9,13 +9,15 @@ export function initTutorial () {
     return
   }
 
-  introJs().setOptions({
+  const intro = introJs().setOptions({
     dontShowAgain: true, // Override styles to hide the checkbox
     nextLabel: 'Suivant',
     prevLabel: 'Précédent',
     doneLabel: 'Terminé',
     highlightClass: 'custom-introjs-helperLayer',
     showBullets: false,
+    disableInteraction: true,
+    exitOnOverlayClick: false,
     steps: [
       {
         title: 'Nouveauté',
@@ -28,10 +30,12 @@ export function initTutorial () {
         element: spellCheckStatus
       }
     ]
-  }).start()
-  // Set a cookie to prevent showing the tutorial again
-  // This ensures the tutorial is shown only once
-  introJs().setDontShowAgain(true)
+  })
+  intro.onexit(() => {
+    document.querySelector('body').classList.remove('introjs-tour')
+    intro.setDontShowAgain(true)
+  })
+  intro.start()
 }
 
 export function closeTutorial () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,7 @@ __metadata:
     html-webpack-plugin: 4.5.2
     i18n: 0.15.1
     imports-loader: 1.2.0
+    intro.js: 7.2.0
     ionicons: 2.0.1
     is-svg: 4.4.0
     jquery: 3.7.1
@@ -7935,6 +7936,13 @@ __metadata:
   version: 2.2.0
   resolution: "interpret@npm:2.2.0"
   checksum: f51efef7cb8d02da16408ffa3504cd6053014c5aeb7bb8c223727e053e4235bf565e45d67028b0c8740d917c603807aa3c27d7bd2f21bf20b6417e2bb3e5fd6e
+  languageName: node
+  linkType: hard
+
+"intro.js@npm:7.2.0":
+  version: 7.2.0
+  resolution: "intro.js@npm:7.2.0"
+  checksum: 466b95f64d746890e1dce20c28c9813e74ea238fbd7270abf90997c1e70d8ad146a7035feee02f47a5b9328b65fdc54a4b2c204bfca07c605f18122d888de3a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To-do:
- [ ] Fix vertical overflow
- [ ] ~~Style the pop-in~~, edit: won't lose time on a tutorial seen once, 2min.
- [x] Disable interactivity of high-lighted elements

Brainsto:
- Add more steps?
- Specify a unique cookie name to prevent potential collisions when more tutorials are added in the future
- Improve the UX by making the Grist form more visible (currently, it's quite hidden).
- Have a way to trigger the tutorial manually?
- How to avoid increase in support if user are unhappy? 

